### PR TITLE
Support novel semantic version version bumps "date" and "predate"

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-	"cSpell.words": [
-		"octokit",
-		"repos",
-		"subcommands"
-	]
-}

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ## Upcoming
 
+- Feature: Support standard semantic version bumps "preminor", "prepatch", "premajor"
+
+- Feature: Support novel semantic version version bump  "date" and "predate" for date-based versioning e.g. "2022.11.0"
+
 ## carnesen-dev-0.0.0 (2022-02-25)
 
 Initial release

--- a/cspell.json
+++ b/cspell.json
@@ -1,0 +1,16 @@
+{
+	"version": "0.2",
+	"ignorePaths": [],
+	"dictionaryDefinitions": [],
+	"dictionaries": [],
+	"words": [
+		"octokit",
+		"premajor",
+		"preminor",
+		"prepatch",
+		"repos",
+		"subcommands"
+	],
+	"ignoreWords": [],
+	"import": []
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -6,12 +6,14 @@ import { releaseCommand } from './release-command';
 import { prCommand } from './pr-command';
 import { CLI_NAME } from '../constants';
 import { writeLicenseCommand } from './write-license-command';
+import { prepareReleaseCommand } from './prepare-release-command';
 
 const rootBranch = CliCommandGroup({
 	name: CLI_NAME,
 	description: 'A command-line interface (CLI) for @carnesen projects',
 	subcommands: [
 		prCommand,
+		prepareReleaseCommand,
 		releaseCommand,
 		localsBranch,
 		remotesBranch,

--- a/src/cli/prepare-release-command.ts
+++ b/src/cli/prepare-release-command.ts
@@ -1,0 +1,21 @@
+import { CliCommand, CliStringChoiceArgGroup } from '@carnesen/cli';
+import { SEMVER_BUMPS } from '../constants';
+import { NpmProject } from '../npm-project';
+
+export const prepareReleaseCommand = CliCommand({
+	name: 'prepare-release',
+	hidden: true,
+	namedArgGroups: {
+		semverBump: CliStringChoiceArgGroup({
+			choices: SEMVER_BUMPS,
+			description: `
+        SemVer segment to bump for the release
+      `,
+			required: true,
+		}),
+	},
+	action({ namedValues: { semverBump } }) {
+		const topLevelNpmProject = new NpmProject();
+		topLevelNpmProject.prepareRelease(semverBump);
+	},
+});

--- a/src/cli/release-command.ts
+++ b/src/cli/release-command.ts
@@ -75,7 +75,7 @@ In <inDir>/<project> for each <project>:
 
 * Run "npm version" to bump the package.json version unless semverBump="none"
 
-* If bump is not "prerelease", update ${CHANGELOG_FILE_NAME} replacing 
+* If bump does not start with "pre", update ${CHANGELOG_FILE_NAME} replacing 
 "Upcoming" with the current release name and today's date
 
 * Copy ${PROJECT_FILE_NAMES.join(', ')} to <outDir>/<inDir>/<project>
@@ -84,7 +84,7 @@ In <outDir>/<inDir>/<project> for each <project>:
 
 * If private is not \`true\` in package.json, run "npm publish"
 
-If bump is not "prerelease", at the top level of the repository:
+If bump does not start with "pre", at the top level of the repository:
 
 * Create a new commit from "." with message e.g. "project0-0.1.2 project1-0.1.2"
 
@@ -110,7 +110,7 @@ If bump is not "prerelease", at the top level of the repository:
 			outNpmProject.npmPublish();
 			return releaseSpec;
 		});
-		if (semverBump !== 'prerelease') {
+		if (!semverBump.startsWith('pre')) {
 			const gitRepo = GithubRepo.fromCwd();
 			gitRepo.commitTagPushRelease(releaseSpecs);
 		}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -23,8 +23,13 @@ export const PROJECT_FILE_NAMES = [
 export const SEMVER_BUMPS = [
 	'none',
 	'prerelease',
+	'preminor',
 	'minor',
+	'premajor',
 	'major',
+	'prepatch',
 	'patch',
+	'predate',
+	'date',
 ] as const;
 export type SemverBump = typeof SEMVER_BUMPS[number];

--- a/src/util/current-full-year-factory.ts
+++ b/src/util/current-full-year-factory.ts
@@ -1,3 +1,0 @@
-export function currentFullYearFactory(): string {
-	return new Date().getFullYear().toString();
-}

--- a/src/util/now-month-factory.ts
+++ b/src/util/now-month-factory.ts
@@ -1,0 +1,3 @@
+export function nowMonthFactory(): string {
+	return (new Date().getMonth() + 1).toString();
+}

--- a/src/util/now-year-factory.ts
+++ b/src/util/now-year-factory.ts
@@ -1,0 +1,3 @@
+export function nowYearFactory(): string {
+	return new Date().getFullYear().toString();
+}

--- a/src/util/prepare-next-date-semver.ts
+++ b/src/util/prepare-next-date-semver.ts
@@ -1,0 +1,24 @@
+import { nowMonthFactory } from './now-month-factory';
+import { nowYearFactory } from './now-year-factory';
+
+export function prepareNextDateSemver(semver: string): string {
+	const [year, month, sequenceNumber] = semver.split('.');
+	const fourDigitsRegexp = /^[0-9]{4}$/;
+	const oneOrMoreDigitsRegexp = /^[0-9]+$/;
+	if (
+		!(
+			fourDigitsRegexp.test(year) &&
+			oneOrMoreDigitsRegexp.test(month) &&
+			oneOrMoreDigitsRegexp.test(sequenceNumber)
+		)
+	) {
+		throw new Error(`Current version "${semver}" is not a date semver`);
+	}
+	const nowYear = nowYearFactory();
+	const nowMonth = nowMonthFactory();
+	const nextSequenceNumber =
+		nowYear === year && nowMonth === month
+			? (Number(sequenceNumber) + 1).toString()
+			: '0';
+	return [nowYear, nowMonth, nextSequenceNumber].join('.');
+}

--- a/src/util/prepare-next-license.ts
+++ b/src/util/prepare-next-license.ts
@@ -1,5 +1,5 @@
 import { LicenseName } from '../types/license-name';
-import { currentFullYearFactory } from './current-full-year-factory';
+import { nowYearFactory } from './now-year-factory';
 import { mitLicenseFactory, MIT_LICENSE_HEADER } from './mit-license-factory';
 import {
 	proprietaryLicenseFactory,
@@ -10,7 +10,7 @@ export function prepareNextLicense(
 	license: string,
 	licenseName?: LicenseName,
 ): string {
-	const currentFullYear = currentFullYearFactory();
+	const nowYear = nowYearFactory();
 	let licenseFactory: (yearRange: string) => string;
 	if (
 		licenseName === 'proprietary' ||
@@ -28,18 +28,18 @@ export function prepareNextLicense(
 	const singleFullYearMatched = license.match(/ ([0-9]{4}) /);
 	if (singleFullYearMatched) {
 		const existingSingleFullYear = singleFullYearMatched[1];
-		if (existingSingleFullYear === currentFullYear) {
-			return licenseFactory(currentFullYear);
+		if (existingSingleFullYear === nowYear) {
+			return licenseFactory(nowYear);
 		}
-		return licenseFactory(`${existingSingleFullYear}-${currentFullYear}`);
+		return licenseFactory(`${existingSingleFullYear}-${nowYear}`);
 	}
 
 	const fullYearRangeMatched = license.match(/ ([0-9]{4})-[0-9]{4} /);
 	if (fullYearRangeMatched) {
 		const [, initialYear] = fullYearRangeMatched;
-		return licenseFactory(`${initialYear}-${currentFullYear}`);
+		return licenseFactory(`${initialYear}-${nowYear}`);
 	}
 
 	// Existing license does not have a year or year range
-	return licenseFactory(currentFullYear);
+	return licenseFactory(nowYear);
 }


### PR DESCRIPTION
These new semver bumps are for date-based versioning e.g. "2022.11.0"

Support standard semantic version bumps "preminor", "prepatch",
"premajor"
